### PR TITLE
Add support for getting display type

### DIFF
--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
@@ -44,6 +44,8 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   void poweron();
   void poweroff();
   void on_shutdown() override;
+  
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
 
  protected:
   void HOT draw_absolute_pixel_internal(int x, int y, Color color) override;

--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
@@ -47,7 +47,7 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   void on_shutdown() override;
 
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0)  
-  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_GRAYSCALE; }
 #endif
 
  protected:

--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
@@ -4,6 +4,7 @@
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/version.h"
 
 #ifndef EPD_DRIVER
 #define EPD_DRIVER
@@ -44,8 +45,10 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   void poweron();
   void poweroff();
   void on_shutdown() override;
-  
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0)  
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+#endif
 
  protected:
   void HOT draw_absolute_pixel_internal(int x, int y, Color color) override;


### PR DESCRIPTION
# What does this implement/fix? 

A breaking change PR (esphome/esphome#3430) was merged into esphome that will prevent your code from compiling.
Adding this change will allow it to build again on ESPHome >= 2022.6

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** esphome/esphome#3430

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
