### PR TITLE
Update display driver.

### DIFF
--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.cpp
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.cpp
@@ -8,23 +8,9 @@ namespace lilygo_t5_47_display {
 
 static const char *const TAG = "lilygo_t5_47_display";
 
-float LilygoT547Display::get_setup_priority() const { return esphome::setup_priority::LATE; }
-
-void LilygoT547Display::set_clear_screen(bool clear) { this->clear_ = clear; }
-void LilygoT547Display::set_power_off_delay_enabled(bool power_off_delay_enabled) {
-  this->power_off_delay_enabled_ = power_off_delay_enabled;
-}
-void LilygoT547Display::set_landscape(bool landscape) { this->landscape_ = landscape; }
-
-void LilygoT547Display::set_temperature(uint32_t temperature) { this->temperature_ = temperature; }
-
-int LilygoT547Display::get_width_internal() { return 960; }
-
-int LilygoT547Display::get_height_internal() { return 540; }
-
 void LilygoT547Display::setup() {
   epd_init(EPD_OPTIONS_DEFAULT);
-  hl = epd_hl_init(WAVEFORM);
+  this->hl = epd_hl_init(WAVEFORM);
   if (landscape_) {
     EpdRotation orientation = EPD_ROT_LANDSCAPE;
     epd_set_rotation(orientation);
@@ -32,36 +18,39 @@ void LilygoT547Display::setup() {
     EpdRotation orientation = EPD_ROT_PORTRAIT;
     epd_set_rotation(orientation);
   }
-  fb = epd_hl_get_framebuffer(&hl);
+  this->fb = epd_hl_get_framebuffer(&this->hl);
+  this->partial_updates_ = this->full_update_every_;
 }
 
 void LilygoT547Display::update() {
-  if (this->init_clear_executed_ == false && this->clear_ == true) {
-    LilygoT547Display::clear();
+  epd_poweron();
+  if (this->init_clear_executed_ == false && this->clear_screen_ == true) {
+    this->clear_();
     this->init_clear_executed_ = true;
+  } else {
+    if (this->partial_updates_ == 0 && this->full_update_every_ != 0) {
+      this->clear_();
+    } else {
+      this->partial_updates_--;
+    }
   }
+  // Clear Framebuffer
+  epd_hl_set_all_white(&this->hl);
+
   this->do_update_();
-  LilygoT547Display::flush_screen_changes();
-}
-
-void LilygoT547Display::clear() {
-  epd_poweron();
-  epd_fullclear(&hl, this->temperature_);
-  epd_poweroff();
-}
-
-void LilygoT547Display::flush_screen_changes() {
-  epd_poweron();
-  err = epd_hl_update_screen(&hl, MODE_GC16, this->temperature_);
+  this->flush_screen_changes_();
   if (this->power_off_delay_enabled_ == true) {
     delay(700);
   }
   epd_poweroff();
 }
 
-void LilygoT547Display::set_all_white() { epd_hl_set_all_white(&hl); }
-void LilygoT547Display::poweron() { epd_poweron(); }
-void LilygoT547Display::poweroff() { epd_poweroff(); }
+void LilygoT547Display::clear_() {
+  this->partial_updates_ = this->full_update_every_;
+  epd_fullclear(&this->hl, this->temperature_);
+}
+
+void LilygoT547Display::flush_screen_changes_() { this->err = epd_hl_update_screen(&this->hl, MODE_GC16, this->temperature_); }
 
 void LilygoT547Display::on_shutdown() {
   ESP_LOGI(TAG, "Shutting down Lilygo T5-4.7 screen");
@@ -71,11 +60,11 @@ void LilygoT547Display::on_shutdown() {
 
 void HOT LilygoT547Display::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (color.red == 255 && color.green == 255 && color.blue == 255) {
-    epd_draw_pixel(x, y, 0, fb);
+    epd_draw_pixel(x, y, 0, this->fb);
   } else {
     int col = (0.2126 * color.red) + (0.7152 * color.green) + (0.0722 * color.blue);
     int cl = 255 - col;
-    epd_draw_pixel(x, y, cl, fb);
+    epd_draw_pixel(x, y, cl, this->fb);
   }
 }
 

--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.cpp
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.cpp
@@ -9,7 +9,7 @@ namespace lilygo_t5_47_display {
 static const char *const TAG = "lilygo_t5_47_display";
 
 void LilygoT547Display::setup() {
-  epd_init(EPD_OPTIONS_DEFAULT);
+  epd_init(this->low_memory_mode_ ? (EpdInitOptions) (EPD_LUT_1K | EPD_FEED_QUEUE_8) : EPD_OPTIONS_DEFAULT);
   this->hl = epd_hl_init(WAVEFORM);
   if (landscape_) {
     EpdRotation orientation = EPD_ROT_LANDSCAPE;
@@ -50,7 +50,9 @@ void LilygoT547Display::clear_() {
   epd_fullclear(&this->hl, this->temperature_);
 }
 
-void LilygoT547Display::flush_screen_changes_() { this->err = epd_hl_update_screen(&this->hl, MODE_GC16, this->temperature_); }
+void LilygoT547Display::flush_screen_changes_() {
+  this->err = epd_hl_update_screen(&this->hl, MODE_GC16, this->temperature_);
+}
 
 void LilygoT547Display::on_shutdown() {
   ESP_LOGI(TAG, "Shutting down Lilygo T5-4.7 screen");

--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
@@ -17,47 +17,48 @@ namespace lilygo_t5_47_display {
 
 // LilyGo-EPD47
 class LilygoT547Display : public PollingComponent, public display::DisplayBuffer {
- protected:
-  EpdiyHighlevelState hl;
-  // ambient temperature around device
-  uint8_t *fb;
-  enum EpdDrawError err;
-
  public:
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 
-  void set_clear_screen(bool clear);
-  void set_landscape(bool landscape);
-  void set_power_off_delay_enabled(bool power_off_delay_enabled);
-  void set_temperature(uint32_t temperature);
-
-  int get_width_internal();
-
-  int get_height_internal();
-
-  void setup() override;
-
-  void update() override;
-
-  void clear();
-  void flush_screen_changes();
-  void set_all_white();
-  void poweron();
-  void poweroff();
-  void on_shutdown() override;
-
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0)  
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022, 6, 0)
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
 #endif
+
+  void set_clear_screen(bool val) { this->clear_screen_ = val; }
+  void set_landscape(bool val) { this->landscape_ = val; }
+  void set_power_off_delay_enabled(bool val) { this->power_off_delay_enabled_ = val; }
+  void set_temperature(uint8_t val) { this->temperature_ = val; }
+  void set_full_update_every(uint8_t val) { this->full_update_every_ = val; }
+
+  int get_width_internal() override { return 960; }
+  int get_height_internal() override { return 540; }
+
+  void setup() override;
+  void update() override;
+
+  void set_all_white() { epd_hl_set_all_white(&hl); }
+  void poweron() { epd_poweron(); }
+  void poweroff() { epd_poweroff(); }
+  void on_shutdown() override;
 
  protected:
   void HOT draw_absolute_pixel_internal(int x, int y, Color color) override;
 
-  bool clear_;
+  void clear_();
+  void flush_screen_changes_();
+
   bool init_clear_executed_ = false;
-  bool temperature_;
-  bool power_off_delay_enabled_;
+  EpdiyHighlevelState hl;
+  uint8_t *fb;
+  enum EpdDrawError err;
+
+  bool clear_screen_;
   bool landscape_;
+  bool power_off_delay_enabled_;
+  // ambient temperature around device
+  uint8_t temperature_;
+  uint8_t full_update_every_;
+  uint32_t partial_updates_{0};
 };
 
 }  // namespace lilygo_t5_47_display

--- a/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
+++ b/esphome/components/lilygo_t5_47_display/LilygoT547Display.h
@@ -27,8 +27,9 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   void set_clear_screen(bool val) { this->clear_screen_ = val; }
   void set_landscape(bool val) { this->landscape_ = val; }
   void set_power_off_delay_enabled(bool val) { this->power_off_delay_enabled_ = val; }
-  void set_temperature(uint8_t val) { this->temperature_ = val; }
+  void set_temperature(int8_t val) { this->temperature_ = val; }
   void set_full_update_every(uint8_t val) { this->full_update_every_ = val; }
+  void set_low_memory_mode(bool val) { this->low_memory_mode_ = val; }
 
   int get_width_internal() override { return 960; }
   int get_height_internal() override { return 540; }
@@ -56,9 +57,10 @@ class LilygoT547Display : public PollingComponent, public display::DisplayBuffer
   bool landscape_;
   bool power_off_delay_enabled_;
   // ambient temperature around device
-  uint8_t temperature_;
+  int8_t temperature_;
   uint8_t full_update_every_;
-  uint32_t partial_updates_{0};
+  uint8_t partial_updates_{0};
+  bool low_memory_mode_;
 };
 
 }  // namespace lilygo_t5_47_display

--- a/esphome/components/lilygo_t5_47_display/display.py
+++ b/esphome/components/lilygo_t5_47_display/display.py
@@ -6,7 +6,10 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_PAGES,
+    CONF_AUTO_CLEAR_ENABLED,
 )
+
+AUTO_LOAD = ["psram"]
 
 CONF_CLEAR = "clear"
 CONF_TEMPERATURE = "temperature"
@@ -22,11 +25,13 @@ CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(Epaper),
-            cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
+            cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint8_t,
             cv.Optional(CONF_CLEAR, default=True): cv.boolean,
             cv.Optional(CONF_POWER_OFF_DELAY_ENABLED, default=False): cv.boolean,
             cv.Optional(CONF_LANDSCAPE, default=True): cv.boolean,
-            cv.Optional(CONF_TEMPERATURE, default=23): cv.uint32_t,
+            cv.Optional(CONF_TEMPERATURE, default=23): cv.uint8_t,
+            # Overwrite default of base display class.
+            cv.Optional(CONF_AUTO_CLEAR_ENABLED, default=False): cv.boolean,
         }
     ).extend(cv.polling_component_schema("5s")),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
@@ -48,7 +53,7 @@ async def to_code(config):
     cg.add(var.set_temperature(config[CONF_TEMPERATURE]))
     cg.add(var.set_landscape(config[CONF_LANDSCAPE]))
     cg.add(var.set_power_off_delay_enabled(config[CONF_POWER_OFF_DELAY_ENABLED]))
+    cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
     cg.add_library("https://github.com/vroland/epdiy.git", None)
-    cg.add_build_flag("-DBOARD_HAS_PSRAM")
     cg.add_build_flag("-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1")
     cg.add_build_flag("-DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47")

--- a/esphome/components/lilygo_t5_47_display/display.py
+++ b/esphome/components/lilygo_t5_47_display/display.py
@@ -15,6 +15,7 @@ CONF_CLEAR = "clear"
 CONF_TEMPERATURE = "temperature"
 CONF_LANDSCAPE = "landscape"
 CONF_POWER_OFF_DELAY_ENABLED = "power_off_delay_enabled"
+CONF_LOW_MEMORY_MODE = "low_memory_mode"
 
 Epaper_ns = cg.esphome_ns.namespace("lilygo_t5_47_display")
 Epaper = Epaper_ns.class_(
@@ -29,9 +30,10 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CLEAR, default=True): cv.boolean,
             cv.Optional(CONF_POWER_OFF_DELAY_ENABLED, default=False): cv.boolean,
             cv.Optional(CONF_LANDSCAPE, default=True): cv.boolean,
-            cv.Optional(CONF_TEMPERATURE, default=23): cv.uint8_t,
+            cv.Optional(CONF_TEMPERATURE, default=23): cv.int_range(min=-127, max=127),
             # Overwrite default of base display class.
             cv.Optional(CONF_AUTO_CLEAR_ENABLED, default=False): cv.boolean,
+            cv.Optional(CONF_LOW_MEMORY_MODE, default=False): cv.boolean,
         }
     ).extend(cv.polling_component_schema("5s")),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
@@ -54,6 +56,7 @@ async def to_code(config):
     cg.add(var.set_landscape(config[CONF_LANDSCAPE]))
     cg.add(var.set_power_off_delay_enabled(config[CONF_POWER_OFF_DELAY_ENABLED]))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
+    cg.add(var.set_low_memory_mode(config[CONF_LOW_MEMORY_MODE]))
     cg.add_library("https://github.com/vroland/epdiy.git", None)
     cg.add_build_flag("-DCONFIG_EPD_DISPLAY_TYPE_ED047TC1")
     cg.add_build_flag("-DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47")


### PR DESCRIPTION
# What does this implement/fix? 

This PR contains the following changes:

- Cleanup and order of header file.
- Move trivial functions to header file. 
- Use quick `epd_hl_set_all_white` instead of pixel by pixel clear before `do_update_`.
- Support for full screen refresh after n partial updates.
- Single power on and off operation for one screen update. Instead of twice.
- Use `psram`component instead of adding build flag.
